### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(Openmpt REQUIRED)
 find_package(ZLIB REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${ZLIB_INCLUDE_DIR}
+include_directories(${ZLIB_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR}/..
                     ${OPENMPT_INCLUDE_DIRS})
 
 set(OPENMPT_SOURCES src/OpenMptCodec.cpp)
 
-set(DEPLIBS ${kodiplatform_LIBRARIES} ${OPENMPT_LIBRARIES} ${ZLIB_LIBRARIES})
+set(DEPLIBS ${OPENMPT_LIBRARIES} ${ZLIB_LIBRARIES})
 
 build_addon(audiodecoder.openmpt OPENMPT DEPLIBS)
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-audiodecoder-openmpt
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev, libopenmpt-dev
+               libopenmpt-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.openmpt binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.